### PR TITLE
fix: pass actual working signal to createAutoScroll in AgentView

### DIFF
--- a/src/components/AgentView.tsx
+++ b/src/components/AgentView.tsx
@@ -126,11 +126,6 @@ function AgentViewInner(props: AgentViewProps) {
   let scrollRef: HTMLDivElement | undefined
   let rafId: number | undefined
   const composerState = createSessionComposerState({ closeMs: 320 })
-  const autoScroll = createAutoScroll({
-    working: () => true,
-    overflowAnchor: "dynamic",
-    onUserInteracted: () => scheduleJumpStateUpdate(),
-  })
 
   const activeSessionId = createMemo(() => {
     const id = params.id || props.sessionId
@@ -157,6 +152,12 @@ function AgentViewInner(props: AgentViewProps) {
   })
   const status = createMemo(() => statusInfo().type)
   const working = createMemo(() => status() !== "idle")
+
+  const autoScroll = createAutoScroll({
+    working,
+    overflowAnchor: "dynamic",
+    onUserInteracted: () => scheduleJumpStateUpdate(),
+  })
   const sessionEventError = createMemo(() => {
     const sessionID = activeSessionId()
     const error = sessionID ? sync.data.session_error[sessionID] : undefined


### PR DESCRIPTION
The working option was hardcoded to () => true, causing auto-scroll to always believe the session is active. This forced the view to scroll to bottom on every content resize — even in idle sessions. Pass the existing working memo (derived from session status) instead.