### PR TITLE
#16: Agent cannot be stopped once code execution starts

### DIFF
--- a/src/shob-ported/prompt-input/submit.ts
+++ b/src/shob-ported/prompt-input/submit.ts
@@ -223,7 +223,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
   }
 
   const abort = async () => {
-    const sessionID = params.id
+    const sessionID = input.info()?.id || params.id
     if (!sessionID) return Promise.resolve()
 
     globalSync.todo.set(sessionID, [])


### PR DESCRIPTION
## Description

Fixes an issue where the agent cannot be stopped after code execution has started.

### Changes
- Restored the ability to stop an active agent during code execution.
- Improved cancellation handling for long-running tasks.
- Prevented the agent from becoming unresponsive while executing code.

Closes #16

## Type of change

- [x] Bug fix 