### PR TITLE
#22: Compact Handling for Large Pasted Prompts

### DIFF
--- a/src/context/prompt.tsx
+++ b/src/context/prompt.tsx
@@ -36,7 +36,16 @@ export interface ImageAttachmentPart {
   dataUrl: string
 }
 
-export type ContentPart = TextPart | FileAttachmentPart | AgentPart | ImageAttachmentPart
+export interface PastePart {
+  type: "paste"
+  id: string
+  content: string
+  preview: string
+  lineCount: number
+  charCount: number
+}
+
+export type ContentPart = TextPart | FileAttachmentPart | AgentPart | ImageAttachmentPart | PastePart
 export type Prompt = ContentPart[]
 
 export type FileContextItem = {
@@ -71,6 +80,8 @@ function isPartEqual(partA: ContentPart, partB: ContentPart) {
       return partB.type === "agent" && partA.name === partB.name
     case "image":
       return partB.type === "image" && partA.id === partB.id
+    case "paste":
+      return partB.type === "paste" && partA.id === partB.id && partA.content === partB.content
   }
 }
 
@@ -91,6 +102,7 @@ function clonePart(part: ContentPart): ContentPart {
   if (part.type === "text") return { ...part }
   if (part.type === "image") return { ...part }
   if (part.type === "agent") return { ...part }
+  if (part.type === "paste") return { ...part }
   return {
     ...part,
     selection: cloneSelection(part.selection),

--- a/src/shob-ported/prompt-input.tsx
+++ b/src/shob-ported/prompt-input.tsx
@@ -14,6 +14,7 @@ import {
   ImageAttachmentPart,
   AgentPart,
   FileAttachmentPart,
+  PastePart,
 } from "@/context/prompt"
 import { useLayout } from "@/context/layout"
 import { useSDK } from "@/context/sdk"
@@ -58,6 +59,8 @@ import { PromptImageAttachments } from "./prompt-input/image-attachments"
 import { PromptDragOverlay } from "./prompt-input/drag-overlay"
 import { promptPlaceholder } from "./prompt-input/placeholder"
 import { ImagePreview } from "@opencode-ai/ui/image-preview"
+import { PromptPasteAttachments } from "./prompt-input/paste-attachments"
+import { PastePreviewDialog } from "./prompt-input/paste-preview-dialog"
 import { useQueries } from "@tanstack/solid-query"
 import { useQueryOptions, pathKey } from "./mock-session-layout"
 import { formatServerError } from "@/utils/server-errors"
@@ -317,6 +320,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
   const imageAttachments = createMemo(() =>
     prompt.current().filter((part): part is ImageAttachmentPart => part.type === "image"),
+  )
+  const pasteAttachments = createMemo(() =>
+    prompt.current().filter((part): part is PastePart => part.type === "paste"),
   )
 
   const [store, setStore] = createStore<{
@@ -658,7 +664,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     setComposing(false)
     requestAnimationFrame(() => {
       if (composing()) return
-      reconcile(prompt.current().filter((part) => part.type !== "image"))
+      reconcile(prompt.current().filter((part) => part.type !== "image" && part.type !== "paste"))
     })
   }
 
@@ -748,17 +754,18 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     if (!cmd) return
     closePopover()
     const images = imageAttachments()
+    const pastes = pasteAttachments()
 
     if (cmd.type === "custom") {
       const text = `/${cmd.trigger} `
       setEditorText(text)
-      prompt.set([{ type: "text", content: text, start: 0, end: text.length }, ...images], text.length)
+      prompt.set([{ type: "text", content: text, start: 0, end: text.length }, ...images, ...pastes], text.length)
       focusEditorEnd()
       return
     }
 
     clearEditor()
-    prompt.set([...DEFAULT_PROMPT, ...images], 0)
+    prompt.set([...DEFAULT_PROMPT, ...images, ...pastes], 0)
     command.trigger(cmd.id, "slash")
   }
 
@@ -811,14 +818,14 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     }
 
     if (parts.length === 0) parts.push({ type: "text", content: guardedText, start: 0, end: guardedText.length })
-    return [...parts, ...imageAttachments()]
+    return [...parts, ...imageAttachments(), ...pasteAttachments()]
   }
 
   const improvePrompt = async () => {
     if (improvingPrompt()) return
 
     const liveParts = parseFromDOM()
-    const nextPrompt = [...liveParts, ...imageAttachments()]
+    const nextPrompt = [...liveParts, ...imageAttachments(), ...pasteAttachments()]
     const liveText = promptPlainText(nextPrompt)
     const liveCursor = getCursorPosition(editorRef)
     if (!isPromptEqual(prompt.current(), nextPrompt) || prompt.cursor() !== liveCursor) {
@@ -1029,7 +1036,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       () => prompt.current(),
       (parts) => {
         if (composing()) return
-        reconcile(parts.filter((part) => part.type !== "image"))
+        reconcile(parts.filter((part) => part.type !== "image" && part.type !== "paste"))
       },
     ),
   )
@@ -1133,7 +1140,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const hasNonText = rawParts.some((part) => part.type !== "text")
     const textContent = (editorRef.textContent ?? "").replace(/\u200B/g, "")
     const shouldReset =
-      textContent.length === 0 && rawText.replace(/\n/g, "").length === 0 && !hasNonText && images.length === 0
+      textContent.length === 0 &&
+      rawText.replace(/\n/g, "").length === 0 &&
+      !hasNonText &&
+      images.length === 0 &&
+      pasteAttachments().length === 0
 
     if (shouldReset) {
       closePopover()
@@ -1168,7 +1179,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     resetHistoryNavigation()
 
     mirror.input = true
-    prompt.set([...rawParts, ...images], cursorPosition)
+    const pastes = pasteAttachments()
+    prompt.set([...rawParts, ...images, ...pastes], cursorPosition)
     queueScroll()
   }
 
@@ -1316,7 +1328,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return true
   }
 
-  const { addAttachments, removeAttachment, handlePaste } = createPromptAttachments({
+  const { addAttachments, removeAttachment, removePaste, handlePaste } = createPromptAttachments({
     editor: () => editorRef,
     isDialogActive: () => !!dialog.active,
     setDraggingType: (type) => setStore("draggingType", type),
@@ -1627,6 +1639,18 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
           }
           onRemove={removeAttachment}
           removeLabel={language.t("prompt.attachment.remove")}
+        />
+        <PromptPasteAttachments
+          pastes={pasteAttachments()}
+          onOpen={(paste) =>
+            dialog.show(() => (
+              <PastePreviewDialog
+                content={paste.content}
+                filename={`Pasted Text (${(paste.charCount / 1024).toFixed(1)} KB)`}
+              />
+            ))
+          }
+          onRemove={removePaste}
         />
         <div
           class="agent-terminal-prompt-line relative flex items-start justify-between gap-3 p-4"

--- a/src/shob-ported/prompt-input/attachments.ts
+++ b/src/shob-ported/prompt-input/attachments.ts
@@ -149,6 +149,25 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
 
     const text = normalizePaste(plainText)
 
+    const lineCount = text.split("\n").length
+    if (text.length >= 1000 || lineCount >= 8) {
+      const id = uuid()
+      const lines = text.split("\n")
+      const preview = lines.slice(0, 3).join("\n")
+      const pastePart = {
+        type: "paste" as const,
+        id,
+        content: text,
+        preview,
+        lineCount,
+        charCount: text.length,
+      }
+      const editor = input.editor()
+      const cursor = prompt.cursor() ?? (editor ? getCursorPosition(editor) : 0)
+      prompt.set([...prompt.current(), pastePart], cursor)
+      return
+    }
+
     const put = () => {
       if (input.addPart({ type: "text", content: text, start: 0, end: 0 })) return true
       input.focusEditor()
@@ -215,10 +234,17 @@ export function createPromptAttachments(input: PromptAttachmentsInput) {
     makeEventListener(document, "drop", handleGlobalDrop)
   })
 
+  const removePaste = (id: string) => {
+    const current = prompt.current()
+    const next = current.filter((part) => part.type !== "paste" || part.id !== id)
+    prompt.set(next, prompt.cursor())
+  }
+
   return {
     addAttachment,
     addAttachments,
     removeAttachment,
+    removePaste,
     handlePaste,
   }
 }

--- a/src/shob-ported/prompt-input/history.ts
+++ b/src/shob-ported/prompt-input/history.ts
@@ -36,6 +36,7 @@ export function clonePromptParts(prompt: Prompt): Prompt {
     if (part.type === "text") return { ...part }
     if (part.type === "image") return { ...part }
     if (part.type === "agent") return { ...part }
+    if (part.type === "paste") return { ...part }
     return {
       ...part,
       selection: part.selection ? { ...part.selection } : undefined,
@@ -137,6 +138,7 @@ function isPromptEqual(promptA: PromptHistoryStoredEntry, promptB: PromptHistory
     }
     if (partA.type === "agent" && partA.name !== (partB.type === "agent" ? partB.name : "")) return false
     if (partA.type === "image" && partA.id !== (partB.type === "image" ? partB.id : "")) return false
+    if (partA.type === "paste" && (partB.type !== "paste" || partA.id !== partB.id || partA.content !== partB.content)) return false
   }
   if (entryA.comments.length !== entryB.comments.length) return false
   for (let i = 0; i < entryA.comments.length; i++) {

--- a/src/shob-ported/prompt-input/paste-attachments.tsx
+++ b/src/shob-ported/prompt-input/paste-attachments.tsx
@@ -1,0 +1,57 @@
+import { Component, For, Show } from "solid-js"
+import { FileText, X } from "lucide-solid"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
+import type { PastePart } from "@/context/prompt"
+
+type PromptPasteAttachmentsProps = {
+  pastes: PastePart[]
+  onOpen: (paste: PastePart) => void
+  onRemove: (id: string) => void
+}
+
+export const PromptPasteAttachments: Component<PromptPasteAttachmentsProps> = (props) => {
+  const formatSize = (chars: number) => {
+    if (chars < 1024) return `${chars} B`
+    return `${(chars / 1024).toFixed(1)} KB`
+  }
+
+  return (
+    <Show when={props.pastes.length > 0}>
+      <div class="flex flex-wrap gap-2 px-3 pt-3">
+        <For each={props.pastes}>
+          {(paste, index) => (
+            <Tooltip value={paste.preview} placement="top" contentClass="break-all whitespace-pre font-mono text-[11px] max-w-xs p-2">
+              <div
+                class="group relative flex items-center gap-2.5 rounded-lg border border-border-weak-base bg-surface-raised-base hover:bg-surface-raised-base-hover hover:border-border-strong-base transition-all p-2.5 cursor-pointer max-w-[280px] min-w-[200px]"
+                onClick={() => props.onOpen(paste)}
+              >
+                <div class="flex size-8 shrink-0 items-center justify-center rounded-md bg-background-stronger text-text-weak group-hover:text-primary transition-colors">
+                  <FileText size={16} />
+                </div>
+                <div class="flex-1 min-w-0">
+                  <div class="text-[12px] font-semibold text-text-strong truncate">
+                    Pasted Text {props.pastes.length > 1 ? `#${index() + 1}` : ""}
+                  </div>
+                  <div class="text-[11px] text-text-weaker truncate">
+                    {formatSize(paste.charCount)} · {paste.lineCount} lines
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    props.onRemove(paste.id)
+                  }}
+                  class="size-6 rounded-md hover:bg-background-stronger flex items-center justify-center text-text-weak hover:text-text-strong transition-colors"
+                  aria-label="Remove pasted text"
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            </Tooltip>
+          )}
+        </For>
+      </div>
+    </Show>
+  )
+}

--- a/src/shob-ported/prompt-input/paste-preview-dialog.tsx
+++ b/src/shob-ported/prompt-input/paste-preview-dialog.tsx
@@ -1,0 +1,17 @@
+import { Component } from "solid-js"
+import { Dialog } from "@opencode-ai/ui/dialog"
+
+type PastePreviewDialogProps = {
+  content: string
+  filename: string
+}
+
+export const PastePreviewDialog: Component<PastePreviewDialogProps> = (props) => {
+  return (
+    <Dialog title={props.filename} transition>
+      <div class="mt-4 max-h-[60vh] overflow-auto rounded-lg border border-border-weak-base bg-background p-4 font-mono text-[13px] leading-5 whitespace-pre select-text text-text-base">
+        {props.content}
+      </div>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Description

Adds compact handling for large pasted prompts to improve readability and reduce visual clutter in the chat interface.

### Changes
- Displays large pasted content in a collapsed/compact view.
- Preserves access to the full content through expansion.
- Improves message layout and overall chat usability.
- Prevents oversized prompts from overwhelming the conversation view.

Closes #22

## Type of change

[screen-capture (5).webm](https://github.com/user-attachments/assets/b4d8add9-9dd2-4f09-957e-ff29ff18ff4d)




- [x] Feature