### PR TITLE
feat(browser): Mobile/responsive viewport simulator, Degen overlay preview, Codex-style mouse control

### DIFF
--- a/electron/browser-control.ts
+++ b/electron/browser-control.ts
@@ -22,6 +22,13 @@ type BrowserAction =
   | "close"
   | "state"
   | "click"
+  | "double_click"
+  | "right_click"
+  | "mouse_move"
+  | "mouse_down"
+  | "mouse_up"
+  | "hover"
+  | "drag"
   | "type"
   | "press"
   | "scroll"
@@ -29,9 +36,19 @@ type BrowserAction =
   | "forward"
   | "reload"
   | "set_degen_mode"
+  | "set_viewport"
   | "extract"
   | "evaluate"
   | "screenshot";
+
+export type BrowserViewport = {
+  width: number;
+  height: number;
+  deviceScaleFactor: number;
+  mobile: boolean;
+  userAgent: string | null;
+  preset: string | null;
+};
 
 export type BrowserControlRequest = {
   action?: BrowserAction;
@@ -48,6 +65,25 @@ export type BrowserControlRequest = {
   deltaY?: number;
   javascript?: string;
   maxLength?: number;
+  // Viewport / device emulation
+  viewportWidth?: number;
+  viewportHeight?: number;
+  deviceScaleFactor?: number;
+  mobile?: boolean;
+  userAgent?: string | null;
+  preset?: string | null;
+  // Mouse / drag
+  fromX?: number;
+  fromY?: number;
+  toX?: number;
+  toY?: number;
+  fromRef?: string;
+  toRef?: string;
+  button?: "left" | "right" | "middle";
+  clickCount?: number;
+  steps?: number;
+  delayMs?: number;
+  modifiers?: string[];
 };
 
 export type BrowserElementSnapshot = {
@@ -75,6 +111,7 @@ export type BrowserState = {
   error?: string | null;
   text?: string;
   elements?: BrowserElementSnapshot[];
+  viewport?: BrowserViewport;
 };
 
 export type BrowserControlResponse = {
@@ -574,6 +611,14 @@ export function createBrowserControl(options: BrowserControlOptions) {
   let lastNavigationError: string | null = null;
   let browserTheme = DEFAULT_BROWSER_THEME;
   let degenMode = false;
+  let viewport: BrowserViewport = {
+    width: 0,
+    height: 0,
+    deviceScaleFactor: 1,
+    mobile: false,
+    userAgent: null,
+    preset: "responsive",
+  };
   const token = crypto.randomBytes(32).toString("base64url");
   const degenMessagePrefix = `__SHOB_BROWSER_DEGEN_PICK__${token}:`;
   const lightStateDetail: BrowserStateDetail = { includeText: false, includeElements: false };
@@ -611,6 +656,26 @@ export function createBrowserControl(options: BrowserControlOptions) {
     });
     contents.on("did-stop-loading", () => {
       if (degenMode) void syncDegenMode();
+      // Re-apply mobile viewport meta tag after navigation if device emulation is on
+      if (viewport.mobile && viewport.width > 0) {
+        const w = JSON.stringify(viewport.width);
+        const dpr = JSON.stringify(viewport.deviceScaleFactor);
+        void executeInPage(
+          `(() => { try {
+            try { Object.defineProperty(window, "devicePixelRatio", { configurable: true, get: () => ${dpr} }); } catch (e) {}
+            let meta = document.querySelector('meta[name="viewport"][data-shob-emulated="1"]');
+            if (!meta) {
+              meta = document.createElement("meta");
+              meta.setAttribute("name", "viewport");
+              meta.setAttribute("data-shob-emulated", "1");
+              document.head && document.head.appendChild(meta);
+            }
+            meta.setAttribute("content", "width=" + ${w} + ", initial-scale=1, maximum-scale=1, user-scalable=no");
+            return true;
+          } catch (e) { return false; } })()`,
+          false,
+        );
+      }
       publish();
     });
     contents.on("page-title-updated", publish);
@@ -808,6 +873,7 @@ export function createBrowserControl(options: BrowserControlOptions) {
         degenMode,
         text: "",
         elements: [],
+        viewport,
       };
     }
 
@@ -822,6 +888,7 @@ export function createBrowserControl(options: BrowserControlOptions) {
       canGoForward: contents.canGoForward(),
       degenMode,
       error: lastNavigationError,
+      viewport,
     };
     if (detail?.includeText) state.text = await getPageText();
     if (detail?.includeElements) state.elements = await getElements();
@@ -917,15 +984,77 @@ export function createBrowserControl(options: BrowserControlOptions) {
         appliedBounds = null;
         return { ok: true, action, state: await getState(lightStateDetail) };
       }
-      case "click": {
+      case "click":
+      case "double_click":
+      case "right_click": {
+        const nextView = ensureView();
+        addToWindow();
+        const point = await pointForRef(request.ref);
+        const x = point?.x ?? clampInt(request.x, Math.floor(bounds.width / 2), -20_000, 20_000);
+        const y = point?.y ?? clampInt(request.y, Math.floor(bounds.height / 2), -20_000, 20_000);
+        const button: "left" | "right" | "middle" =
+          action === "right_click" ? "right" : (request.button ?? "left");
+        const clickCount = action === "double_click" ? 2 : (request.clickCount ?? 1);
+        const modifiers = Array.isArray(request.modifiers) ? request.modifiers as any : undefined;
+        nextView.webContents.sendInputEvent({ type: "mouseMove", x, y, modifiers });
+        for (let i = 0; i < clickCount; i++) {
+          nextView.webContents.sendInputEvent({ type: "mouseDown", x, y, button, clickCount: i + 1, modifiers });
+          nextView.webContents.sendInputEvent({ type: "mouseUp", x, y, button, clickCount: i + 1, modifiers });
+        }
+        break;
+      }
+      case "mouse_move":
+      case "hover": {
         const nextView = ensureView();
         addToWindow();
         const point = await pointForRef(request.ref);
         const x = point?.x ?? clampInt(request.x, Math.floor(bounds.width / 2), -20_000, 20_000);
         const y = point?.y ?? clampInt(request.y, Math.floor(bounds.height / 2), -20_000, 20_000);
         nextView.webContents.sendInputEvent({ type: "mouseMove", x, y });
-        nextView.webContents.sendInputEvent({ type: "mouseDown", x, y, button: "left", clickCount: 1 });
-        nextView.webContents.sendInputEvent({ type: "mouseUp", x, y, button: "left", clickCount: 1 });
+        break;
+      }
+      case "mouse_down": {
+        const nextView = ensureView();
+        addToWindow();
+        const point = await pointForRef(request.ref);
+        const x = point?.x ?? clampInt(request.x, Math.floor(bounds.width / 2), -20_000, 20_000);
+        const y = point?.y ?? clampInt(request.y, Math.floor(bounds.height / 2), -20_000, 20_000);
+        const button: "left" | "right" | "middle" = request.button ?? "left";
+        nextView.webContents.sendInputEvent({ type: "mouseDown", x, y, button, clickCount: 1 });
+        break;
+      }
+      case "mouse_up": {
+        const nextView = ensureView();
+        addToWindow();
+        const point = await pointForRef(request.ref);
+        const x = point?.x ?? clampInt(request.x, Math.floor(bounds.width / 2), -20_000, 20_000);
+        const y = point?.y ?? clampInt(request.y, Math.floor(bounds.height / 2), -20_000, 20_000);
+        const button: "left" | "right" | "middle" = request.button ?? "left";
+        nextView.webContents.sendInputEvent({ type: "mouseUp", x, y, button, clickCount: 1 });
+        break;
+      }
+      case "drag": {
+        const nextView = ensureView();
+        addToWindow();
+        const fromPoint = request.fromRef ? await pointForRef(request.fromRef) : null;
+        const toPoint = request.toRef ? await pointForRef(request.toRef) : null;
+        const fx = fromPoint?.x ?? clampInt(request.fromX ?? request.x, 0, -20_000, 20_000);
+        const fy = fromPoint?.y ?? clampInt(request.fromY ?? request.y, 0, -20_000, 20_000);
+        const tx = toPoint?.x ?? clampInt(request.toX, 0, -20_000, 20_000);
+        const ty = toPoint?.y ?? clampInt(request.toY, 0, -20_000, 20_000);
+        const button: "left" | "right" | "middle" = request.button ?? "left";
+        const steps = Math.max(2, Math.min(60, clampInt(request.steps, 20, 2, 200)));
+        const delayMs = Math.max(0, Math.min(50, clampInt(request.delayMs, 8, 0, 200)));
+        nextView.webContents.sendInputEvent({ type: "mouseMove", x: fx, y: fy });
+        nextView.webContents.sendInputEvent({ type: "mouseDown", x: fx, y: fy, button, clickCount: 1 });
+        for (let i = 1; i <= steps; i++) {
+          const t = i / steps;
+          const ix = Math.round(fx + (tx - fx) * t);
+          const iy = Math.round(fy + (ty - fy) * t);
+          nextView.webContents.sendInputEvent({ type: "mouseMove", x: ix, y: iy });
+          if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+        }
+        nextView.webContents.sendInputEvent({ type: "mouseUp", x: tx, y: ty, button, clickCount: 1 });
         break;
       }
       case "type": {
@@ -974,6 +1103,72 @@ export function createBrowserControl(options: BrowserControlOptions) {
         addToWindow();
         await syncDegenMode();
         break;
+      case "set_viewport": {
+        const nextView = ensureView();
+        addToWindow();
+        const presetRaw = typeof request.preset === "string" ? request.preset : null;
+        const width = clampInt(request.viewportWidth, 0, 0, 10_000);
+        const height = clampInt(request.viewportHeight, 0, 0, 10_000);
+        const dpr = Number.isFinite(request.deviceScaleFactor)
+          ? Math.max(1, Math.min(4, Number(request.deviceScaleFactor)))
+          : 1;
+        const mobile = Boolean(request.mobile);
+        viewport = {
+          width,
+          height,
+          deviceScaleFactor: dpr,
+          mobile,
+          userAgent: typeof request.userAgent === "string" ? request.userAgent : null,
+          preset: presetRaw,
+        };
+        try {
+          if (viewport.userAgent) {
+            nextView.webContents.setUserAgent(viewport.userAgent);
+          } else {
+            // Reset to default UA
+            nextView.webContents.setUserAgent(nextView.webContents.session.getUserAgent());
+          }
+        } catch (error) {
+          console.warn("[shob] browser setUserAgent failed:", error);
+        }
+        // Inject CSS-level device emulation: clamp viewport via meta + scale via JS.
+        // We let bounds handle the actual painted region via the frontend frame.
+        const dprJs = JSON.stringify(dpr);
+        const widthJs = JSON.stringify(width);
+        const heightJs = JSON.stringify(height);
+        const mobileJs = JSON.stringify(mobile);
+        await executeInPage(
+          `(() => {
+            try {
+              const w = ${widthJs}, h = ${heightJs}, dpr = ${dprJs}, mobile = ${mobileJs};
+              // Override devicePixelRatio for the page
+              if (dpr > 0) {
+                try { Object.defineProperty(window, "devicePixelRatio", { configurable: true, get: () => dpr }); } catch (e) {}
+              }
+              // Inject (or update) a meta viewport so responsive sites lay out correctly
+              let meta = document.querySelector('meta[name="viewport"][data-shob-emulated="1"]');
+              if (mobile && w > 0) {
+                if (!meta) {
+                  meta = document.createElement("meta");
+                  meta.setAttribute("name", "viewport");
+                  meta.setAttribute("data-shob-emulated", "1");
+                  document.head && document.head.appendChild(meta);
+                }
+                meta.setAttribute("content", "width=" + w + ", initial-scale=1, maximum-scale=1, user-scalable=no");
+              } else if (meta) {
+                meta.remove();
+              }
+              return true;
+            } catch (e) { return false; }
+          })()`,
+          false,
+        );
+        if (mobile) {
+          // Reload so UA-sniffing scripts pick up the mobile UA
+          try { nextView.webContents.reloadIgnoringCache(); } catch (e) { /* noop */ }
+        }
+        break;
+      }
       case "extract": {
         const text = await getPageText(request.maxLength ?? DEFAULT_TEXT_LIMIT);
         return { ok: true, action, state: await getState({ includeText: false, includeElements: true }), text };

--- a/src/components/BrowserTab.tsx
+++ b/src/components/BrowserTab.tsx
@@ -1,5 +1,18 @@
-import { createEffect, createSignal, onCleanup, Show } from "solid-js"
-import { ArrowLeft, ArrowRight, Crosshair, Globe, Loader2, RotateCw, Search, X } from "lucide-solid"
+import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js"
+import {
+  ArrowLeft,
+  ArrowRight,
+  Crosshair,
+  Globe,
+  Loader2,
+  Monitor,
+  RotateCcw,
+  RotateCw,
+  Search,
+  Smartphone,
+  Tablet,
+  X,
+} from "lucide-solid"
 import { nativeApi } from "@/services/native"
 import type {
   ElectronBrowserAction,
@@ -26,6 +39,47 @@ const EMPTY_STATE: ElectronBrowserState = {
   elements: [],
 }
 
+type DevicePreset = {
+  id: string
+  label: string
+  icon: "monitor" | "smartphone" | "tablet"
+  width: number
+  height: number
+  dpr: number
+  mobile: boolean
+  userAgent: string | null
+}
+
+const RESPONSIVE_PRESET: DevicePreset = {
+  id: "responsive",
+  label: "Responsive",
+  icon: "monitor",
+  width: 0,
+  height: 0,
+  dpr: 1,
+  mobile: false,
+  userAgent: null,
+}
+
+const UA_IPHONE =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+const UA_PIXEL =
+  "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
+const UA_IPAD =
+  "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+const UA_GALAXY =
+  "Mozilla/5.0 (Linux; Android 14; SM-S928B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
+
+const DEVICE_PRESETS: DevicePreset[] = [
+  RESPONSIVE_PRESET,
+  { id: "iphone-15", label: "iPhone 15", icon: "smartphone", width: 393, height: 852, dpr: 3, mobile: true, userAgent: UA_IPHONE },
+  { id: "iphone-se", label: "iPhone SE", icon: "smartphone", width: 375, height: 667, dpr: 2, mobile: true, userAgent: UA_IPHONE },
+  { id: "pixel-8", label: "Pixel 8", icon: "smartphone", width: 412, height: 915, dpr: 2.625, mobile: true, userAgent: UA_PIXEL },
+  { id: "galaxy-s24", label: "Galaxy S24", icon: "smartphone", width: 384, height: 832, dpr: 3, mobile: true, userAgent: UA_GALAXY },
+  { id: "ipad", label: "iPad", icon: "tablet", width: 820, height: 1180, dpr: 2, mobile: true, userAgent: UA_IPAD },
+  { id: "ipad-mini", label: "iPad Mini", icon: "tablet", width: 768, height: 1024, dpr: 2, mobile: true, userAgent: UA_IPAD },
+]
+
 function browserBounds(element: HTMLElement) {
   const rect = element.getBoundingClientRect()
   return {
@@ -36,11 +90,32 @@ function browserBounds(element: HTMLElement) {
   }
 }
 
+function PresetIcon(props: { kind: "monitor" | "smartphone" | "tablet"; size?: number }) {
+  return (
+    <Show
+      when={props.kind === "smartphone"}
+      fallback={
+        <Show when={props.kind === "tablet"} fallback={<Monitor size={props.size ?? 13} />}>
+          <Tablet size={props.size ?? 13} />
+        </Show>
+      }
+    >
+      <Smartphone size={props.size ?? 13} />
+    </Show>
+  )
+}
+
 export function BrowserTab(props: BrowserTabProps) {
   const [state, setState] = createSignal<ElectronBrowserState>(EMPTY_STATE)
   const [address, setAddress] = createSignal("")
   const [editingAddress, setEditingAddress] = createSignal(false)
+  const [presetId, setPresetId] = createSignal<string>("responsive")
+  const [rotated, setRotated] = createSignal(false)
+  const [showDeviceMenu, setShowDeviceMenu] = createSignal(false)
+  const [selectedEl, setSelectedEl] = createSignal<ElectronBrowserElementSelection | null>(null)
+  const [showSelectionPreview, setShowSelectionPreview] = createSignal(true)
   let viewportRef: HTMLDivElement | undefined
+  let frameRef: HTMLDivElement | undefined
   let addressInputRef: HTMLInputElement | undefined
   let resizeObserver: ResizeObserver | undefined
   let syncFrame: number | undefined
@@ -53,6 +128,16 @@ export function BrowserTab(props: BrowserTabProps) {
   let openUnlisten: (() => void) | undefined
   let selectionUnlisten: (() => void) | undefined
 
+  const currentPreset = createMemo(() => DEVICE_PRESETS.find((p) => p.id === presetId()) ?? RESPONSIVE_PRESET)
+
+  const presetDimensions = createMemo(() => {
+    const p = currentPreset()
+    if (p.width === 0 || p.height === 0) return null
+    const w = rotated() ? p.height : p.width
+    const h = rotated() ? p.width : p.height
+    return { width: w, height: h, dpr: p.dpr, mobile: p.mobile, userAgent: p.userAgent, preset: p.id }
+  })
+
   const invoke = (action: ElectronBrowserAction, payload: Record<string, unknown> = {}) =>
     nativeApi.invoke("browser_action", { action, detail: "light", ...payload }).then((result: ElectronBrowserActionResult) => {
       setState(result.state)
@@ -63,8 +148,10 @@ export function BrowserTab(props: BrowserTabProps) {
   const panelResizing = () => props.panelResizing?.() === true
 
   const syncBounds = (force = false) => {
-    if (!props.active() || !viewportRef) return
-    const bounds = browserBounds(viewportRef)
+    if (!props.active()) return
+    const target = frameRef ?? viewportRef
+    if (!target) return
+    const bounds = browserBounds(target)
     const boundsKey = `${bounds.x}:${bounds.y}:${bounds.width}:${bounds.height}`
     if (!force && boundsKey === lastSyncedBoundsKey) return
     lastSyncedBoundsKey = boundsKey
@@ -100,6 +187,48 @@ export function BrowserTab(props: BrowserTabProps) {
 
   const scheduleObservedBounds = () => scheduleSyncBounds()
 
+  const applyViewport = () => {
+    const dims = presetDimensions()
+    if (!dims) {
+      void invoke("set_viewport", {
+        viewportWidth: 0,
+        viewportHeight: 0,
+        deviceScaleFactor: 1,
+        mobile: false,
+        userAgent: null,
+        preset: "responsive",
+      }).catch((error) => console.warn("[browser-tab] set_viewport failed:", error))
+      return
+    }
+    void invoke("set_viewport", {
+      viewportWidth: dims.width,
+      viewportHeight: dims.height,
+      deviceScaleFactor: dims.dpr,
+      mobile: dims.mobile,
+      userAgent: dims.userAgent,
+      preset: dims.preset,
+    }).catch((error) => console.warn("[browser-tab] set_viewport failed:", error))
+  }
+
+  const selectPreset = (id: string) => {
+    setPresetId(id)
+    setShowDeviceMenu(false)
+    setRotated(false)
+    requestAnimationFrame(() => {
+      applyViewport()
+      scheduleSyncBounds(true)
+    })
+  }
+
+  const toggleRotate = () => {
+    if (!presetDimensions()) return
+    setRotated((r) => !r)
+    requestAnimationFrame(() => {
+      applyViewport()
+      scheduleSyncBounds(true)
+    })
+  }
+
   const navigate = () => {
     const url = address().trim()
     setEditingAddress(false)
@@ -122,6 +251,12 @@ export function BrowserTab(props: BrowserTabProps) {
     void invoke("set_degen_mode", { enabled: !state().degenMode }).catch((error) => {
       console.error("[browser-tab] set_degen_mode failed:", error)
     })
+  }
+
+  const copySelector = () => {
+    const sel = selectedEl()?.selector
+    if (!sel) return
+    void navigator.clipboard?.writeText(sel).catch(() => undefined)
   }
 
   createEffect(() => {
@@ -157,6 +292,14 @@ export function BrowserTab(props: BrowserTabProps) {
     window.addEventListener("resize", scheduleObservedBounds)
   })
 
+  // Resync bounds whenever the chosen device preset or rotation changes
+  createEffect(() => {
+    presetId()
+    rotated()
+    if (!props.active()) return
+    requestAnimationFrame(() => scheduleSyncBounds(true))
+  })
+
   createEffect(() => {
     void nativeApi.listen<ElectronBrowserState>("browser:state", (event) => {
       setState(event.payload)
@@ -172,6 +315,8 @@ export function BrowserTab(props: BrowserTabProps) {
       openUnlisten = unlisten
     })
     void nativeApi.listen<ElectronBrowserElementSelection>("browser:element-selected", (event) => {
+      setSelectedEl(event.payload)
+      setShowSelectionPreview(true)
       window.dispatchEvent(new CustomEvent("shob-browser-element-selected", { detail: event.payload }))
     }).then((unlisten) => {
       selectionUnlisten = unlisten
@@ -196,6 +341,10 @@ export function BrowserTab(props: BrowserTabProps) {
           0% { transform: translateX(-120%); width: 32%; }
           45% { width: 56%; }
           100% { transform: translateX(320%); width: 32%; }
+        }
+        @keyframes shob-fade-in-up {
+          from { opacity: 0; transform: translateY(6px); }
+          to { opacity: 1; transform: translateY(0); }
         }
       `}</style>
       <form
@@ -284,7 +433,71 @@ export function BrowserTab(props: BrowserTabProps) {
             <Search size={13} />
           </button>
         </div>
+
+        {/* Device preset dropdown */}
+        <div class="relative shrink-0">
+          <button
+            type="button"
+            class="h-7 inline-flex items-center gap-1.5 rounded-md px-2 text-[12px] text-text-weak hover:bg-surface-raised-base-hover hover:text-text-strong"
+            classList={{
+              "bg-sky-500/10 text-sky-300 ring-1 ring-sky-400/30": currentPreset().id !== "responsive",
+            }}
+            aria-label="Device viewport"
+            title="Mobile / responsive viewport"
+            onClick={() => setShowDeviceMenu((v) => !v)}
+          >
+            <PresetIcon kind={currentPreset().icon} />
+            <span class="hidden sm:inline">{currentPreset().label}</span>
+            <Show when={presetDimensions()}>
+              {(dims) => (
+                <span class="text-text-weak text-[10px] tabular-nums">
+                  {dims().width}×{dims().height}
+                </span>
+              )}
+            </Show>
+          </button>
+          <Show when={showDeviceMenu()}>
+            <div
+              class="absolute right-0 top-full z-50 mt-1 w-56 overflow-hidden rounded-md border border-border-weaker-base bg-background-stronger py-1 shadow-lg"
+              style={{ animation: "shob-fade-in-up 120ms ease-out" }}
+            >
+              <For each={DEVICE_PRESETS}>
+                {(preset) => (
+                  <button
+                    type="button"
+                    class="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-[12px] text-text hover:bg-surface-raised-base-hover"
+                    classList={{ "bg-surface-raised-base-hover": presetId() === preset.id }}
+                    onClick={() => selectPreset(preset.id)}
+                  >
+                    <span class="flex items-center gap-2">
+                      <PresetIcon kind={preset.icon} size={12} />
+                      <span>{preset.label}</span>
+                    </span>
+                    <Show when={preset.width > 0}>
+                      <span class="text-text-weak text-[10px] tabular-nums">
+                        {preset.width}×{preset.height}
+                      </span>
+                    </Show>
+                  </button>
+                )}
+              </For>
+            </div>
+          </Show>
+        </div>
+
+        {/* Rotate */}
+        <button
+          type="button"
+          class="size-7 shrink-0 inline-flex items-center justify-center rounded-md text-text-weak hover:bg-surface-raised-base-hover hover:text-text disabled:opacity-40 disabled:hover:bg-transparent"
+          disabled={!presetDimensions()}
+          aria-label="Rotate viewport"
+          title="Rotate viewport"
+          onClick={toggleRotate}
+        >
+          <RotateCcw size={14} />
+        </button>
       </form>
+
       <div class="h-0.5 shrink-0 overflow-hidden bg-transparent">
         <div
           class="h-full rounded-full bg-sky-400 opacity-0 transition-opacity"
@@ -294,7 +507,117 @@ export function BrowserTab(props: BrowserTabProps) {
           }}
         />
       </div>
-      <div ref={viewportRef} class="relative min-h-0 flex-1 overflow-hidden bg-background-base" />
+
+      {/* Viewport area. In responsive mode the WebContentsView fills the entire region.
+          In device mode, we center a fixed-size frame and sync bounds to that frame. */}
+      <div
+        ref={viewportRef}
+        class="relative min-h-0 flex-1 overflow-auto"
+        classList={{
+          "bg-background-base": !presetDimensions(),
+          "bg-[#0a0a0a] flex items-start justify-center p-4": !!presetDimensions(),
+        }}
+      >
+        <Show when={presetDimensions()} fallback={null}>
+          {(dims) => (
+            <div class="flex flex-col items-center gap-2">
+              <div class="text-[10px] uppercase tracking-wider text-text-weak tabular-nums">
+                {currentPreset().label} · {dims().width}×{dims().height} · DPR {dims().dpr}
+                {rotated() ? " · Landscape" : ""}
+              </div>
+              <div
+                ref={frameRef}
+                class="rounded-[18px] bg-background-base shadow-[0_10px_40px_rgba(0,0,0,0.45)] ring-1 ring-white/10"
+                style={{
+                  width: `${dims().width}px`,
+                  height: `${dims().height}px`,
+                }}
+              />
+            </div>
+          )}
+        </Show>
+
+        {/* Selected element preview (Degen mode) */}
+        <Show when={selectedEl() && showSelectionPreview()}>
+          {(el) => (
+            <div
+              class="absolute bottom-3 right-3 z-40 w-80 max-w-[calc(100%-1.5rem)] rounded-lg border border-sky-400/40 bg-background-stronger/95 backdrop-blur p-3 shadow-xl"
+              style={{ animation: "shob-fade-in-up 140ms ease-out" }}
+            >
+              <div class="flex items-start justify-between gap-2">
+                <div class="flex items-center gap-1.5 min-w-0">
+                  <Crosshair size={12} class="shrink-0 text-sky-400" />
+                  <span class="text-[10px] uppercase tracking-wider text-sky-300">Selected element</span>
+                </div>
+                <button
+                  type="button"
+                  class="size-5 shrink-0 inline-flex items-center justify-center rounded text-text-weak hover:bg-surface-raised-base-hover hover:text-text"
+                  aria-label="Dismiss"
+                  onClick={() => setShowSelectionPreview(false)}
+                >
+                  <X size={11} />
+                </button>
+              </div>
+              <div class="mt-2 flex items-center gap-1.5">
+                <span class="rounded bg-sky-500/15 px-1.5 py-0.5 font-mono text-[10px] text-sky-200">
+                  &lt;{el().tag}&gt;
+                </span>
+                <Show when={el().role}>
+                  <span class="rounded bg-surface-raised-base px-1.5 py-0.5 text-[10px] text-text-weak">
+                    role={el().role}
+                  </span>
+                </Show>
+                <Show when={el().type}>
+                  <span class="rounded bg-surface-raised-base px-1.5 py-0.5 text-[10px] text-text-weak">
+                    type={el().type}
+                  </span>
+                </Show>
+              </div>
+              <Show when={el().text}>
+                <div class="mt-2 line-clamp-2 text-[12px] text-text" title={el().text}>
+                  {el().text}
+                </div>
+              </Show>
+              <Show when={el().href}>
+                <div class="mt-1 truncate font-mono text-[10px] text-text-weak" title={el().href ?? ""}>
+                  → {el().href}
+                </div>
+              </Show>
+              <div
+                class="mt-2 truncate rounded bg-background-base/80 px-2 py-1 font-mono text-[10px] text-text-weak"
+                title={el().selector}
+              >
+                {el().selector}
+              </div>
+              <div class="mt-1 flex items-center gap-2 text-[10px] text-text-weak tabular-nums">
+                <span>
+                  {el().width}×{el().height}
+                </span>
+                <span>·</span>
+                <span>
+                  ({el().x}, {el().y})
+                </span>
+              </div>
+              <div class="mt-2 flex items-center gap-1.5">
+                <button
+                  type="button"
+                  class="rounded-md bg-sky-500/15 px-2 py-1 text-[11px] text-sky-200 hover:bg-sky-500/25"
+                  onClick={copySelector}
+                >
+                  Copy selector
+                </button>
+                <button
+                  type="button"
+                  class="rounded-md bg-surface-raised-base px-2 py-1 text-[11px] text-text-weak hover:bg-surface-raised-base-hover hover:text-text"
+                  onClick={() => setSelectedEl(null)}
+                >
+                  Clear
+                </button>
+              </div>
+            </div>
+          )}
+        </Show>
+      </div>
     </div>
   )
 }

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -92,6 +92,13 @@ export type ElectronBrowserAction =
   | "close"
   | "state"
   | "click"
+  | "double_click"
+  | "right_click"
+  | "mouse_move"
+  | "mouse_down"
+  | "mouse_up"
+  | "hover"
+  | "drag"
   | "type"
   | "press"
   | "scroll"
@@ -99,9 +106,19 @@ export type ElectronBrowserAction =
   | "forward"
   | "reload"
   | "set_degen_mode"
+  | "set_viewport"
   | "extract"
   | "evaluate"
   | "screenshot"
+
+export interface ElectronBrowserViewport {
+  width: number
+  height: number
+  deviceScaleFactor: number
+  mobile: boolean
+  userAgent: string | null
+  preset: string | null
+}
 
 export interface ElectronBrowserBounds {
   x: number
@@ -125,6 +142,23 @@ export interface ElectronBrowserActionRequest {
   deltaY?: number
   javascript?: string
   maxLength?: number
+  viewportWidth?: number
+  viewportHeight?: number
+  deviceScaleFactor?: number
+  mobile?: boolean
+  userAgent?: string | null
+  preset?: string | null
+  fromX?: number
+  fromY?: number
+  toX?: number
+  toY?: number
+  fromRef?: string
+  toRef?: string
+  button?: "left" | "right" | "middle"
+  clickCount?: number
+  steps?: number
+  delayMs?: number
+  modifiers?: string[]
 }
 
 export interface ElectronBrowserElementSnapshot {
@@ -152,6 +186,7 @@ export interface ElectronBrowserState {
   error?: string | null
   text?: string
   elements?: ElectronBrowserElementSnapshot[]
+  viewport?: ElectronBrowserViewport
 }
 
 export interface ElectronBrowserActionResult {


### PR DESCRIPTION
## Summary

Three upgrades to the built-in Browser Panel:

1. **Mobile / responsive viewport simulator** — device presets, rotate, framed viewport
2. **Degen mode visual overlay preview** — floating card showing the picked element
3. **Codex-style full mouse control for the agent** — hover, drag, double/right-click, mouse-down/up primitives

---

### 1. Mobile / Responsive Viewport Simulator

Device dropdown in the browser toolbar with presets:

| Preset | Size | DPR | Mobile UA |
|---|---|---|---|
| Responsive | — | 1 | no |
| iPhone 15 | 393×852 | 3 | yes |
| iPhone SE | 375×667 | 2 | yes |
| Pixel 8 | 412×915 | 2.625 | yes |
| Galaxy S24 | 384×832 | 3 | yes |
| iPad | 820×1180 | 2 | yes |
| iPad Mini | 768×1024 | 2 | yes |

- **Rotate button** swaps width/height for landscape
- Centered framed viewport when a device is active; `WebContentsView` bounds sync to the frame
- New backend action `set_viewport`:
  - `webContents.setUserAgent(...)` so UA-sniffing sites serve the mobile layout
  - Overrides `window.devicePixelRatio` via `Object.defineProperty`
  - Injects `<meta name="viewport" data-shob-emulated="1">` for responsive layout
  - Reloads on mobile toggle so server-side UA branches kick in
  - Meta tag re-applied on every `did-stop-loading`

### 2. Degen Mode Visual Overlay Preview

A floating selection card appears bottom-right of the viewport when an element is picked:

- `<tag>` chip with `role` and `type` badges
- Clipped text + `href`
- Full CSS selector (monospaced, truncated)
- `width×height` and `(x, y)` coords
- **Copy selector** button (uses `navigator.clipboard`)
- **Clear** + dismiss `×`; fade-in-up animation
- Auto-shows on each new pick

No backend change needed — the existing `browser:element-selected` event already emits the full payload.

### 3. Codex-Style Full Mouse Control for the Agent

New agent-callable actions in `browser-control.ts`. All use real `webContents.sendInputEvent` — indistinguishable from a human.

| Action | Notes |
|---|---|
| `click` | Now supports `button` (left/right/middle), `clickCount`, `modifiers` |
| `double_click` | Two `mouseDown`/`mouseUp` pairs with `clickCount: 2` |
| `right_click` | Shortcut for right-button click |
| `mouse_move` / `hover` | True `mouseMove` event (triggers `:hover`, tooltips, dropdowns) |
| `mouse_down` / `mouse_up` | Split primitives for custom gestures |
| `drag` | mouseDown → 2–60 interpolated `mouseMove` steps with configurable `delayMs` → mouseUp |

Targets work via raw `x, y` coords **or** Degen-captured `ref`s. The existing local HTTP server (`127.0.0.1:<port>/browser`, token-protected) means any subagent can drive the browser via plain `POST /browser`.

---

### Files changed

| File | Δ |
|---|---|
| `electron/browser-control.ts` | +~150 lines |
| `src/electron.d.ts` | new action names, `ElectronBrowserViewport`, request fields |
| `src/components/BrowserTab.tsx` | rewrote with device presets, rotate, framed viewport, selection preview |

**Total:** 3 files, +561 / -8

### Backwards compatibility

- All new actions are additive; existing `click` / `type` / `press` / `scroll` / `screenshot` / `extract` / `evaluate` unchanged
- `BrowserState` gets an optional `viewport` field — existing consumers ignore it
- When no device preset is active (default = "Responsive"), the UI behaves exactly as before

### Follow-ups (not in this PR)

- Touch-event emulation for mobile-gesture-only sites
- "Send selection to chat" button on the Degen preview
- Screenshot toolbar button (backend already supports the action)
