### PR TITLE
fix(shell): use platform-aware default shell, fix macOS renderer crash

### DIFF
--- a/electron/session-db.ts
+++ b/electron/session-db.ts
@@ -3,6 +3,8 @@ import { DatabaseSync } from "node:sqlite";
 import fs from "node:fs";
 import path from "node:path";
 
+const DEFAULT_SHELL = process.platform === "win32" ? "powershell.exe" : "/bin/sh";
+
 interface StoredProject {
   id: string;
   name: string;
@@ -264,7 +266,7 @@ function insertSession(db: DatabaseSync, projectId: string, session: StoredSessi
     session.id,
     projectId,
     session.name || 'Terminal',
-    session.shell || "powershell.exe",
+    session.shell || DEFAULT_SHELL,
     optionalString(session.cliTool),
     optionalString(session.pendingLaunchCommand),
     session.pinned ? 1 : 0,

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -73,10 +73,9 @@ function getShellBasename(shell: string): string {
 }
 
 function getDefaultShell(): string {
-  if (typeof process !== "undefined" && process.platform === "win32") {
-    return process.env.COMSPEC || "powershell.exe"
-  }
-  return process.env.SHELL || "/bin/sh"
+  // The renderer has no `process` (contextIsolation + no nodeIntegration);
+  // derive the default shell from the native bridge instead.
+  return nativeApi.defaultShell()
 }
 
 function resolveShell(shell: string | undefined | null, availableShells?: string[]): string {

--- a/src/services/native.ts
+++ b/src/services/native.ts
@@ -21,6 +21,19 @@ export function invokeNative<T extends CommandName>(
 
 export const nativeApi = {
   platform: () => getBridge().platform,
+  /**
+   * Platform-appropriate default shell for the renderer. The renderer runs with
+   * contextIsolation + no nodeIntegration, so `process` does not exist here —
+   * never reference it. Derives the shell from the preload-exposed platform and
+   * falls back to a POSIX shell when the native bridge is unavailable.
+   */
+  defaultShell: (): string => {
+    try {
+      return getBridge().platform === "windows" ? "powershell.exe" : "/bin/sh"
+    } catch {
+      return "/bin/sh"
+    }
+  },
   invoke: invokeNative,
   listen: <T>(channel: string, callback: (event: { payload: T }) => void) =>
     getBridge().listen<T>(channel, callback),

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -422,7 +422,7 @@ export const actions: AppActions = {
         store.availableShells.find((item) => item === store.preferredShell) ??
         store.availableShells[0] ??
         store.preferredShell ??
-        'powershell.exe';
+        nativeApi.defaultShell();
       const installedCliTools = store.cliTools.filter((tool) => tool.installed);
       const selectedCli =
         installedCliTools.find((tool) => tool.id === cliId) ??
@@ -585,7 +585,7 @@ export const actions: AppActions = {
       .filter((session) => !session.time?.archived)
         .map((session): Session => {
           return toLocalShobSession(session, {
-            shell: store.preferredShell ?? (process.platform === 'win32' ? 'powershell.exe' : '/bin/sh'),
+            shell: store.preferredShell ?? nativeApi.defaultShell(),
             pinned: existingPinned.get(session.id) ?? false,
           });
       })

--- a/src/utils/shob-session.ts
+++ b/src/utils/shob-session.ts
@@ -1,4 +1,5 @@
 import type { Session as LocalSession } from "@/types"
+import { nativeApi } from "@/services/native"
 import { sessionTitle } from "./session-title"
 
 const FALLBACK_SESSION_TITLE = "New session"
@@ -75,7 +76,7 @@ export function toLocalShobSession(
     id: session.id,
     name: normalizeShobSessionTitle(session.title),
     parentSessionId: session.parentID ?? null,
-    shell: options.shell ?? (globalThis.navigator?.platform?.toLowerCase().includes("win") ? "powershell.exe" : "/bin/sh"),
+    shell: options.shell ?? nativeApi.defaultShell(),
     cliTool: "opencode",
     pendingLaunchCommand: null,
     pinned: options.pinned ?? false,


### PR DESCRIPTION
## Summary

The renderer runs with `contextIsolation: true` and `nodeIntegration: false`, so **`process` does not exist in the renderer** (there's no `process` shim in the Vite config). Two renderer code paths referenced `process.platform` / `process.env` directly, throwing `ReferenceError: process is not defined`. Several places also defaulted to `powershell.exe` on non‑Windows platforms.

## The crash

`process` is undefined in the renderer, yet it's referenced in:

- **`src/store/index.ts`** — `syncShobSessions` evaluated `process.platform` whenever `preferredShell` was nullish.
- **`src/components/Terminal.tsx`** — `getDefaultShell` fell through to an unguarded `process.env.SHELL`.

`preferredShell` starts `null` and is only set by `loadAvailableShells()`, which is deferred via `requestIdleCallback`. A project with existing sessions can sync **before** that runs, so on a fresh macOS launch the session sync hits `process.platform` → `ReferenceError`, breaking session loading. It also fires permanently if shell detection ever returns an empty list.

## Changes

- Add **`nativeApi.defaultShell()`** — derives the shell from the preload‑exposed `window.shob.platform`, with a POSIX fallback when the bridge is unavailable. Never touches `process`.
- Replace the `process.*` / `navigator.platform` shell logic in the renderer (store sync, `Terminal`, `shob-session`) with the helper.
- Use a `process.platform`‑based default in the **main‑process** session DB (`electron/session-db.ts`) instead of hardcoding `powershell.exe`.

## Testing

- `tsc -b` (renderer) + `tsc -p tsconfig.electron.json` → **0 errors**
- ESLint → clean
- Verified on macOS: sessions load without the `ReferenceError`; new sessions default to `/bin/sh`.

## Scope

The renderer never has `process`, so this is a latent bug on **all** platforms; macOS/Linux were the ones landing on the Windows default. No behavior change for Windows users (still defaults to `powershell.exe` there).
