### PR TITLE
feat(ui): native macOS title-bar layout with integrated traffic lights

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1453,7 +1453,8 @@ async function createWindow() {
     ...(process.platform === "darwin"
       ? {
           titleBarStyle: "hidden" as const,
-          trafficLightPosition: { x: 12, y: 14 },
+          // y positions the lights within the 48px sidebar header
+          trafficLightPosition: { x: 20, y: 17 },
         }
       : {}),
     ...(process.platform === "win32"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { createSignal, onCleanup, onMount, ErrorBoundary, createEffect } from 'solid-js'
+import { createSignal, onCleanup, onMount, ErrorBoundary, createEffect, Show } from 'solid-js'
 import { nativeApi } from './services/native'
 import { TitleBar } from './components/TitleBar'
+import { useWindowChrome } from './utils/window-chrome'
 import { MainView } from './components/MainView'
 import { useStore } from './store'
 import { applyAppTheme, getThemeById, resolveThemeMode, type ResolvedThemeMode } from './theme'
@@ -10,6 +11,7 @@ import { Ico } from './components/Ico'
 
 function App() {
   const { loadProjects, loadCliTools, loadAvailableShells } = useStore()
+  const windowChrome = useWindowChrome()
   const themeId = useStore((s) => s.themeId)
   const colorScheme = useStore((s) => s.colorScheme)
   const [isBooting, setIsBooting] = createSignal(true)
@@ -210,9 +212,11 @@ function App() {
     <>
       <Toast.Region />
       <div class="flex h-full min-h-0 flex-col overflow-hidden">
-        <ErrorBoundary fallback={(error) => <ErrorPage error={error} />}>
-          <TitleBar />
-        </ErrorBoundary>
+        <Show when={!windowChrome.isMac()}>
+          <ErrorBoundary fallback={(error) => <ErrorPage error={error} />}>
+            <TitleBar />
+          </ErrorBoundary>
+        </Show>
         {isBooting() ? (
           <div class="flex-1 bg-black" />
         ) : (

--- a/src/components/AgentView.tsx
+++ b/src/components/AgentView.tsx
@@ -10,6 +10,8 @@ import { DataProvider, FileComponentProvider } from "@opencode-ai/ui/context"
 import { AppIcon } from "@opencode-ai/ui/app-icon"
 import { Icon } from "@opencode-ai/ui/icon"
 import { sessionTitle } from "@/utils/session-title"
+import { MacSidebarReveal } from "./mac-chrome"
+import { useWindowChrome } from "@/utils/window-chrome"
 import { createSessionComposerState } from "@/shob-ported/composer/session-composer-state"
 import { SessionQuestionDock } from "@/shob-ported/composer/session-question-dock"
 import { SessionPermissionDock } from "@/shob-ported/composer/session-permission-dock"
@@ -816,6 +818,11 @@ function AgentViewInner(props: AgentViewProps) {
     sync.set("vcs", { ...sync.data.vcs, branch })
   }
   const title = createMemo(() => currentLocalSession()?.name || sessionTitle(info()?.title) || "New session")
+  const windowChrome = useWindowChrome()
+  // On macOS with a collapsed sidebar the header hosts the reveal controls, which
+  // already supply the traffic-light inset — so drop the header's own left padding.
+  const collapsedHeaderPadLeft = () =>
+    windowChrome.isMac() && !windowChrome.sidebarVisible() ? "0px" : undefined
   const statusInfo = createMemo<SessionStatus>(() => {
     const sessionID = activeSessionId()
     return sessionID ? sync.data.session_status[sessionID] ?? idleStatus : idleStatus
@@ -1778,8 +1785,11 @@ function AgentViewInner(props: AgentViewProps) {
                 <div
                   data-session-title
                   class="agent-terminal-title sticky top-0 z-30 w-full px-3 md:px-4"
+                  classList={{ "mac-drag-region": windowChrome.isMac() }}
+                  style={{ "padding-left": collapsedHeaderPadLeft() }}
                 >
                   <div class="flex w-full items-center gap-2.5">
+                    <MacSidebarReveal />
                     <div class="agent-session-title-cluster flex min-w-0 flex-1 items-center gap-2">
                       <h1 data-slot="session-title-child" class="max-w-[min(56vw,620px)] truncate text-[13px] font-semibold text-text-strong">
                         {title()}
@@ -1849,8 +1859,13 @@ function AgentViewInner(props: AgentViewProps) {
                   }
                 >
                   <div ref={setContentRef} class="agent-terminal-new-session-stage">
-                    <div class="agent-terminal-new-session-header sticky top-0 z-30 w-full px-1 md:px-1.5">
+                    <div
+                      class="agent-terminal-new-session-header sticky top-0 z-30 w-full px-1 md:px-1.5"
+                      classList={{ "mac-drag-region": windowChrome.isMac() }}
+                      style={{ "padding-left": collapsedHeaderPadLeft() }}
+                    >
                       <div class="flex w-full items-center justify-end gap-1.5">
+                        <MacSidebarReveal class="mr-auto" />
                         <Show when={currentBranchName()}>
                           {(branch) => <BranchSwitcher projectPath={activeProjectPath()} currentBranch={branch()} onBranchChanged={setCurrentBranchName} />}
                         </Show>

--- a/src/components/MainView.tsx
+++ b/src/components/MainView.tsx
@@ -6,6 +6,7 @@ import { TerminalPanel } from './TerminalPanel'
 import { BottomTerminalPanel } from './BottomTerminalPanel'
 import { WelcomeScreen } from './WelcomeScreen'
 import { SettingsPage } from './SettingsPage'
+import { MacSidebarRevealRow } from './mac-chrome'
 import { useStore } from '../store'
 import { createFileContext } from '@/context/file'
 import type { FileNode } from '@/types/file-node'
@@ -802,15 +803,18 @@ export function MainView() {
                   </div>
 
                   {projectSessions().length === 0 && (
-                    <div class="h-full min-h-0 min-w-0 flex-1 overflow-hidden">
-                      <WelcomeScreen
-                        projects={projects()}
-                        currentProject={currentProject()}
-                        onOpenFolder={handleOpenFolder}
-                        onCreateSession={handleCreateSession}
-                        onSelectProject={appStore.setCurrentProject}
-                        onToggleFileTree={handleToggleFileTree}
-                      />
+                    <div class="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+                      <MacSidebarRevealRow />
+                      <div class="min-h-0 flex-1 overflow-hidden">
+                        <WelcomeScreen
+                          projects={projects()}
+                          currentProject={currentProject()}
+                          onOpenFolder={handleOpenFolder}
+                          onCreateSession={handleCreateSession}
+                          onSelectProject={appStore.setCurrentProject}
+                          onToggleFileTree={handleToggleFileTree}
+                        />
+                      </div>
                     </div>
                   )}
 
@@ -878,7 +882,10 @@ export function MainView() {
             </div>
           </LayoutProvider>
         ) : (
-          <SettingsPage />
+          <>
+            <MacSidebarRevealRow />
+            <SettingsPage />
+          </>
         )}
       </div>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   useSortableContext,
 } from "@thisbeyond/solid-dnd"
 import { nativeApi } from "../services/native"
+import { MacSidebarHeader } from "./mac-chrome"
 import { useStore } from "../store"
 import type { Project } from "../types"
 import { ResizeHandle } from "@/shob-ported/resize-handle"
@@ -1345,6 +1346,7 @@ export function Sidebar(props: {
           onResizeEnd={endSidebarResize}
         />
         <div class="shob-sidebar relative flex h-full min-h-0 max-h-full flex-col overflow-hidden bg-background-stronger text-text-base select-none">
+          <MacSidebarHeader />
           <div class="sticky top-0 z-20 shrink-0 bg-background-stronger/95 px-1.5 pb-3 pt-2 backdrop-blur">
             <nav class="flex flex-col gap-0.5">
               <SidebarActionButton

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -1,6 +1,7 @@
 import { Show, createMemo } from "solid-js"
 import { AgentView } from "./AgentView"
 import { Terminal } from "./Terminal"
+import { MacSidebarRevealRow } from "./mac-chrome"
 import { useStore } from "../store"
 
 interface TerminalPanelProps {
@@ -23,7 +24,17 @@ export function TerminalPanel(_props: TerminalPanelProps) {
       <Show when={activeSession()}>
         {(session) => (
           <div class="h-full w-full min-h-0 overflow-hidden">
-            <Show when={session().cliTool} fallback={<Terminal sessionId={session().id} />}>
+            <Show
+              when={session().cliTool}
+              fallback={
+                <div class="flex h-full min-h-0 flex-col">
+                  <MacSidebarRevealRow />
+                  <div class="min-h-0 flex-1 overflow-hidden">
+                    <Terminal sessionId={session().id} />
+                  </div>
+                </div>
+              }
+            >
               <AgentView
                 sessionId={session().id}
                 projectPath={currentProject()?.path}

--- a/src/components/mac-chrome.tsx
+++ b/src/components/mac-chrome.tsx
@@ -1,0 +1,98 @@
+import { Show } from "solid-js"
+import { Button } from "@/components/ui/button"
+import { Icon } from "@/components/ui/icon"
+import { useWindowChrome } from "@/utils/window-chrome"
+
+/**
+ * Shared reveal buttons: show-sidebar toggle + new-session. Used by both the
+ * inline chat-header reveal and the standalone reveal row.
+ */
+function RevealButtons(props: { chrome: ReturnType<typeof useWindowChrome>; showNewSession?: boolean }) {
+  return (
+    <>
+      <Button
+        variant="ghost"
+        class="titlebar-icon"
+        onClick={props.chrome.toggleSidebar}
+        title="Show sidebar"
+        aria-label="Show sidebar"
+      >
+        <Icon size="small" name="sidebar" />
+      </Button>
+      <Show when={props.showNewSession ?? true}>
+        <Button
+          variant="ghost"
+          class="titlebar-icon"
+          onClick={props.chrome.createSession}
+          title="Start a new session"
+          aria-label="Start a new session"
+        >
+          <Icon size="small" name="new-session" />
+        </Button>
+      </Show>
+    </>
+  )
+}
+
+/**
+ * Draggable header shown at the top of the sidebar on macOS (sidebar-open state).
+ * Reserves space for the native traffic lights and hosts the collapse toggle.
+ * Renders nothing off macOS.
+ */
+export function MacSidebarHeader() {
+  const chrome = useWindowChrome()
+  return (
+    <Show when={chrome.isMac()}>
+      <div
+        class="mac-drag-region flex h-12 shrink-0 items-center gap-1 px-1.5"
+        style={{ "padding-left": `${chrome.trafficLightInset()}px` }}
+      >
+        <Button
+          variant="ghost"
+          class="titlebar-icon"
+          onClick={chrome.toggleSidebar}
+          title="Hide sidebar"
+          aria-label="Hide sidebar"
+        >
+          <Icon size="small" name="sidebar-active" />
+        </Button>
+      </div>
+    </Show>
+  )
+}
+
+/**
+ * Inline reveal cluster for placement inside an existing view header (e.g. the
+ * chat header's left side). Only renders on macOS when the sidebar is collapsed.
+ */
+export function MacSidebarReveal(props: { class?: string; showNewSession?: boolean }) {
+  const chrome = useWindowChrome()
+  return (
+    <Show when={chrome.isMac() && !chrome.sidebarVisible()}>
+      <div
+        class={`mac-drag-region flex shrink-0 items-center gap-1 ${props.class ?? ""}`}
+        style={{ "padding-left": `${chrome.trafficLightInset()}px` }}
+      >
+        <RevealButtons chrome={chrome} showNewSession={props.showNewSession} />
+      </div>
+    </Show>
+  )
+}
+
+/**
+ * Standalone reveal row for views without their own header (raw terminal,
+ * welcome, settings). Only renders on macOS when the sidebar is collapsed.
+ */
+export function MacSidebarRevealRow() {
+  const chrome = useWindowChrome()
+  return (
+    <Show when={chrome.isMac() && !chrome.sidebarVisible()}>
+      <div
+        class="mac-drag-region flex h-12 shrink-0 items-center gap-1 border-b border-border-weak-base bg-background px-1.5"
+        style={{ "padding-left": `${chrome.trafficLightInset()}px` }}
+      >
+        <RevealButtons chrome={chrome} />
+      </div>
+    </Show>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1338,6 +1338,26 @@ b {
   color: #fff !important;
 }
 
+/* macOS custom window chrome: draggable regions with non-draggable interactive children.
+   Used by the in-sidebar header and the collapsed-sidebar reveal controls so the window
+   can be moved by its top strips while buttons/inputs stay clickable. */
+.mac-drag-region {
+  -webkit-app-region: drag;
+}
+
+.mac-drag-region button,
+.mac-drag-region a,
+.mac-drag-region input,
+.mac-drag-region select,
+.mac-drag-region textarea,
+.mac-drag-region [role="button"],
+.mac-drag-region [role="menuitem"],
+.mac-drag-region [contenteditable="true"],
+.mac-drag-region [contenteditable=""],
+.mac-drag-region .titlebar-icon {
+  -webkit-app-region: no-drag;
+}
+
 /* Agent timeline: terminal-style animated dots spinner for subagent task rows. */
 [data-component="task-tool-card"] [data-component="task-tool-spinner"] {
   display: inline-flex !important;

--- a/src/utils/window-chrome.ts
+++ b/src/utils/window-chrome.ts
@@ -1,0 +1,83 @@
+import { createSignal } from "solid-js"
+import { nativeApi } from "@/services/native"
+
+export type ChromePlatform = "windows" | "macos" | "linux" | "unknown"
+
+/** macOS native traffic-light clearance (matches trafficLightPosition.x in main.ts + light width). */
+export const MAC_TRAFFIC_LIGHT_INSET = 92
+/** Reduced inset in fullscreen, where the traffic lights are hidden. */
+export const MAC_FULLSCREEN_INSET = 10
+
+function mapPlatform(value: string): ChromePlatform {
+  if (value === "windows" || value === "macos" || value === "linux") return value
+  return "unknown"
+}
+
+function readPlatformSync(): ChromePlatform {
+  try {
+    return mapPlatform(nativeApi.platform())
+  } catch {
+    return "unknown"
+  }
+}
+
+// Shared, app-lifetime window-chrome state. Kept at module scope (a singleton) so
+// that components which mount late — e.g. the collapsed-sidebar reveal, which only
+// renders once the sidebar is hidden — read the *current* fullscreen / sidebar
+// state instead of missing the event that set it.
+const [platform] = createSignal<ChromePlatform>(readPlatformSync())
+const [isFullscreen, setIsFullscreen] = createSignal(false)
+const [sidebarVisible, setSidebarVisible] = createSignal(true)
+
+let initialized = false
+
+function ensureInitialized() {
+  if (initialized) return
+  initialized = true
+
+  // Fullscreen is only reported via window-state events (no getter), so we must
+  // start listening before the user enters fullscreen. App.tsx calls
+  // useWindowChrome() at startup, which runs this once.
+  try {
+    void nativeApi
+      .window()
+      .onResized((state) => {
+        if (typeof state?.fullscreen === "boolean") setIsFullscreen(state.fullscreen)
+      })
+      .catch(() => undefined)
+  } catch {
+    /* native bridge unavailable (web) */
+  }
+
+  window.addEventListener("gg-sidebar-state", (event: Event) => {
+    const detail = (event as CustomEvent<{ isSidebarVisible: boolean }>).detail
+    if (detail) setSidebarVisible(Boolean(detail.isSidebarVisible))
+  })
+}
+
+/**
+ * Shared window-chrome state for the custom macOS title-bar layout: platform,
+ * fullscreen, sidebar visibility, plus toggle/create-session actions. Backed by a
+ * singleton so every caller sees consistent, up-to-date values.
+ */
+export function useWindowChrome() {
+  ensureInitialized()
+
+  const isMac = () => platform() === "macos"
+
+  /** Left padding needed to clear the native traffic lights (0 off-mac, reduced in fullscreen). */
+  const trafficLightInset = () => {
+    if (!isMac()) return 0
+    return isFullscreen() ? MAC_FULLSCREEN_INSET : MAC_TRAFFIC_LIGHT_INSET
+  }
+
+  return {
+    platform,
+    isMac,
+    isFullscreen,
+    sidebarVisible,
+    trafficLightInset,
+    toggleSidebar: () => window.dispatchEvent(new Event("gg-toggle-sidebar")),
+    createSession: () => window.dispatchEvent(new Event("gg-create-session")),
+  }
+}


### PR DESCRIPTION
## Summary

On macOS the full‑width custom title bar leaves a large blank, unusable strip to the right of the traffic lights. This integrates the window chrome into the app's columns so content uses the full window height.

<img width="1236" height="1917" alt="image" src="https://github.com/user-attachments/assets/6ca10c34-d84b-4910-ad8f-71e2d57fbf6c" />

**macOS only — Windows/Linux keep the existing `TitleBar` completely untouched.**

> [!WARNING]
> **Windows and Linux should see _no change at all_ from this PR — please confirm that on review.** Every change is gated behind `platform === "macos"`. I developed and tested on macOS only and do **not** have a Windows machine, so I can't verify the no‑change guarantee myself. Confirm that off‑macOS:
> - The full‑width `TitleBar` still renders with working minimize/maximize/close controls.
> - There's **no** sidebar header, **no** reveal rows, and the chat header is **not** draggable.
> - Window dragging and the overall layout are unchanged from `main`.

## Before / After

### Before — full‑width title bar with a blank, unusable strip beside the traffic lights

<img width="1392" height="932" alt="Screenshot 2026-06-13 at 2 02 13 PM" src="https://github.com/user-attachments/assets/7d838a9f-c6db-45eb-af12-92e480baa069" />

<img width="1392" height="932" alt="Screenshot 2026-06-13 at 2 03 37 PM" src="https://github.com/user-attachments/assets/eb7e27a3-d6a7-4ccc-9022-3093768ae9a5" />

<img width="1392" height="932" alt="Screenshot 2026-06-13 at 2 04 20 PM" src="https://github.com/user-attachments/assets/8c93b89a-ee03-4e6e-9b0e-dd77f9602577" />

### After — traffic lights sit above the sidebar; content reaches the window top

<img width="1392" height="932" alt="Screenshot 2026-06-13 at 2 09 50 PM" src="https://github.com/user-attachments/assets/a513496c-1b6d-4d4c-978e-4ab0cbddef54" />

<img width="1392" height="932" alt="Screenshot 2026-06-13 at 2 10 21 PM" src="https://github.com/user-attachments/assets/6bd1e5f7-92e4-4c15-93ca-867ef7be52a8" />

<img width="1392" height="932" alt="Screenshot 2026-06-13 at 2 10 44 PM" src="https://github.com/user-attachments/assets/6a4b5940-3490-45be-9b24-565191bcb4f7" />

## What changed

- Drop the full‑width `TitleBar` on macOS; the content area reaches the window top.
- **Sidebar** gains a draggable header with traffic‑light clearance + the collapse toggle.
- When the sidebar is **collapsed**, reveal controls (show‑sidebar + new‑session) appear **inline on the left of the chat header**, and as a standalone row in the terminal / welcome / settings views — so the sidebar is always recoverable and the toggle's position stays consistent between open and collapsed states.
- Shared singleton **`useWindowChrome()`** tracks platform / fullscreen / sidebar visibility, so late‑mounted reveals read the correct state (fixes the fullscreen inset).
- Chat header is draggable; the traffic‑light inset collapses in fullscreen.
- Native traffic‑light position tuned for the new header (`x: 20, y: 17`).

## Implementation

- New: `src/utils/window-chrome.ts` (state singleton) and `src/components/mac-chrome.tsx` (`MacSidebarHeader`, `MacSidebarReveal`, `MacSidebarRevealRow`).
- `.mac-drag-region` CSS helper marks draggable regions while keeping buttons/inputs clickable.
- Everything is gated behind `platform === "macos"`; `TitleBar` still renders unchanged on Windows/Linux.

## Testing

- `tsc -b` + electron `tsc` → **0 errors**; ESLint → clean.
- Verified on macOS: open & collapsed sidebar, window dragging from both the sidebar and chat headers, all buttons still clickable, fullscreen inset collapse, and reveal coverage across chat / terminal / welcome / settings.

## Scope note

I could not verify Windows/Linux locally, so the change is **fully gated to macOS** — the existing `TitleBar` path is unchanged on those platforms.
