### PR TITLE
fix(updater): disable broken macOS auto-update, link to Releases

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -55,6 +55,11 @@ const ptySessions = new Map<string, PtyRuntime>();
 let downloadedUpdateVersion: string | null = null;
 let availableUpdateVersion: string | null = null;
 let updateDownloadInFlight = false;
+// macOS ships an unsigned build, so Squirrel.Mac cannot apply an in-place update:
+// the download just wastes bandwidth and "Restart & install" silently fails. Until
+// the build is signed + notarized, point macOS users to the Releases page instead.
+const RELEASES_URL = "https://github.com/shobcoder/shob/releases/latest";
+const autoUpdateSupported = process.platform !== "darwin";
 const PTY_REPLAY_BUFFER_LIMIT = 2 * 1024 * 1024;
 const PTY_OUTPUT_FLUSH_DELAY_MS = 500;
 const TITLEBAR_HEIGHT = 40;
@@ -223,7 +228,7 @@ function setupAutoUpdater() {
   if (!app.isPackaged) return;
 
   autoUpdater.autoDownload = false;
-  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.autoInstallOnAppQuit = autoUpdateSupported;
 
   autoUpdater.on("checking-for-update", () => {
     console.log("[shob] checking for update...");
@@ -240,6 +245,12 @@ function setupAutoUpdater() {
     console.log("[shob] update available:", info.version);
     availableUpdateVersion = info.version;
     downloadedUpdateVersion = null;
+    if (!autoUpdateSupported) {
+      // macOS: notify only — do not auto-download an update that can't be applied.
+      updateDownloadInFlight = false;
+      sendUpdateEvent("available", info);
+      return;
+    }
     updateDownloadInFlight = true;
     sendUpdateEvent("available", info);
     autoUpdater.downloadUpdate().catch((error) => {
@@ -1187,12 +1198,20 @@ const handlers: Record<string, (payload?: any) => Promise<any> | any> = {
   },
   install_update: async () => {
     if (!app.isPackaged) return { status: "dev" };
+    if (!autoUpdateSupported) {
+      await shell.openExternal(RELEASES_URL);
+      return { status: "manual", url: RELEASES_URL };
+    }
     if (!downloadedUpdateVersion) return { status: "not-downloaded" };
     autoUpdater.quitAndInstall(false, true);
     return { status: "installing", version: downloadedUpdateVersion };
   },
   download_update: async () => {
     if (!app.isPackaged) return { status: "dev" };
+    if (!autoUpdateSupported) {
+      await shell.openExternal(RELEASES_URL);
+      return { status: "manual", url: RELEASES_URL };
+    }
     if (downloadedUpdateVersion) return { status: "downloaded", version: downloadedUpdateVersion };
     if (updateDownloadInFlight) return { status: "downloading" };
     try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,29 @@ function App() {
 
       try {
         unlistenAvailable = await nativeApi.listen<{ version: string }>("update:available", (event) => {
+          if (windowChrome.isMac()) {
+            // macOS auto-update is disabled (unsigned build) — guide to Releases instead.
+            showToast({
+              title: "Update available",
+              description: `Shob ${event.payload.version} is available. Open the Releases page to download it.`,
+              variant: "default",
+              persistent: true,
+              leading: updateToastLogo(),
+              actions: [
+                {
+                  label: "Open Releases",
+                  onClick: () => {
+                    void nativeApi.invoke("install_update")
+                  },
+                },
+                {
+                  label: "Later",
+                  onClick: "dismiss",
+                },
+              ],
+            })
+            return
+          }
           showToast({
             title: "Update downloading",
             description: `Shob ${event.payload.version} is downloading in the background. You can keep working.`,

--- a/src/components/settings-about.tsx
+++ b/src/components/settings-about.tsx
@@ -1,12 +1,14 @@
 import { createSignal, onMount, onCleanup, Show, Match, Switch } from "solid-js"
 import { Button } from "@/components/ui/button"
 import { nativeApi } from "@/services/native"
-import { CheckCircle2, AlertCircle, Loader2, Download, RotateCcw, Info } from "lucide-solid"
+import { CheckCircle2, AlertCircle, Loader2, Download, RotateCcw, Info, ExternalLink } from "lucide-solid"
 import { Ico } from "@/components/Ico"
+import { useWindowChrome } from "@/utils/window-chrome"
 
 type AboutStatus = "idle" | "checking" | "up-to-date" | "available" | "downloading" | "error" | "installing" | "dev"
 
 export function SettingsAbout() {
+  const chrome = useWindowChrome()
   const [appName, setAppName] = createSignal("shob")
   const [version, setVersion] = createSignal("")
   const [platform, setPlatform] = createSignal("")
@@ -209,6 +211,9 @@ export function SettingsAbout() {
         <div>
           <h3 class="font-medium text-foreground text-sm">Updates</h3>
           <p class="text-xs text-muted-foreground mt-0.5">Check for new versions, download updates in the background, and restart when ready.</p>
+          <Show when={chrome.isMac() && packaged()}>
+            <p class="text-xs text-muted-foreground mt-1">Automatic updates aren't available on macOS yet — download the latest build from the GitHub Releases page.</p>
+          </Show>
         </div>
 
         {/* Status Display */}
@@ -301,30 +306,46 @@ export function SettingsAbout() {
             </Show>
           </Button>
 
-          <Show when={status() === "available" && !updateDownloaded()}>
-            <Button
-              type="button"
-              size="sm"
-              class="bg-blue-600 hover:bg-blue-500 text-white"
-              disabled={downloadInFlight() || status() === "downloading" || status() === "installing"}
-              onClick={() => void downloadUpdate()}
-            >
-              <Download class="h-3.5 w-3.5 mr-1.5" />
-              Download now
-            </Button>
+          <Show when={chrome.isMac()}>
+            <Show when={status() === "available"}>
+              <Button
+                type="button"
+                size="sm"
+                class="bg-blue-600 hover:bg-blue-500 text-white"
+                onClick={() => void nativeApi.invoke("install_update")}
+              >
+                <ExternalLink class="h-3.5 w-3.5 mr-1.5" />
+                Open Releases page
+              </Button>
+            </Show>
           </Show>
 
-          <Show when={updateDownloaded()}>
-            <Button
-              type="button"
-              size="sm"
-              class="bg-emerald-600 hover:bg-emerald-500 text-white"
-              disabled={installInFlight() || status() === "installing"}
-              onClick={() => void installUpdate()}
-            >
-              <RotateCcw class="h-3.5 w-3.5 mr-1.5" />
-              Restart to install
-            </Button>
+          <Show when={!chrome.isMac()}>
+            <Show when={status() === "available" && !updateDownloaded()}>
+              <Button
+                type="button"
+                size="sm"
+                class="bg-blue-600 hover:bg-blue-500 text-white"
+                disabled={downloadInFlight() || status() === "downloading" || status() === "installing"}
+                onClick={() => void downloadUpdate()}
+              >
+                <Download class="h-3.5 w-3.5 mr-1.5" />
+                Download now
+              </Button>
+            </Show>
+
+            <Show when={updateDownloaded()}>
+              <Button
+                type="button"
+                size="sm"
+                class="bg-emerald-600 hover:bg-emerald-500 text-white"
+                disabled={installInFlight() || status() === "installing"}
+                onClick={() => void installUpdate()}
+              >
+                <RotateCcw class="h-3.5 w-3.5 mr-1.5" />
+                Restart to install
+              </Button>
+            </Show>
           </Show>
         </div>
 

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -303,11 +303,11 @@ export interface NativeCommandMap {
   }
   install_update: {
     args: undefined
-    result: { status: "dev" | "not-downloaded" | "installing"; version?: string | null }
+    result: { status: "dev" | "not-downloaded" | "installing" | "manual"; version?: string | null; url?: string }
   }
   download_update: {
     args: undefined
-    result: { status: "dev" | "downloading" | "downloaded" | "error"; version?: string | null; message?: string }
+    result: { status: "dev" | "downloading" | "downloaded" | "error" | "manual"; version?: string | null; message?: string; url?: string }
   }
   opencode_server_start: { args: undefined; result: string }
   browser_action: { args: ElectronBrowserActionRequest; result: ElectronBrowserActionResult }


### PR DESCRIPTION
On macOS the build is unsigned, so in-app auto-update can't apply — it downloads ~130 MB that never installs and **Restart & install** silently fails (#36).

This disables auto-update **on macOS only** and points users to GitHub Releases instead:

- No auto-download on `update-available` (macOS); `download`/`install` open the Releases page.
- Settings page + toast show **"Update available → Open Releases"** instead of the download/install flow.
- Windows/Linux auto-update is unchanged.

**Tested** with a local `0.0.60` build: check shows `0.0.70` available, nothing is downloaded into the updater cache, and "Open Releases" opens the page.

Addresses #36 — signing + notarization (Option 3) remains the eventual full fix.
