### PR TITLE
macOS: fix header controls + detect installed apps in "Open with"

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -558,7 +558,78 @@ async function revealInFinder(targetPath: string) {
   shell.showItemInFolder(targetPath);
 }
 
-type OpenProjectTarget = "vscode" | "explorer" | "terminal" | "git-bash" | "wsl";
+type OpenProjectTarget = string;
+
+// macOS "Open with" catalog. Each entry maps a stable id to its on-disk app
+// name (used both for detection and `open -a`) and the bundled AppIcon id the
+// renderer should show. Unlike the Windows/Linux path, the menu is built from
+// what's actually installed (detectMacOpenWithApps) rather than a fixed list.
+type MacOpenWithKind = "editor" | "terminal" | "reveal";
+interface MacOpenWithApp {
+  id: string;
+  label: string;
+  icon: string;
+  kind: MacOpenWithKind;
+  appName?: string; // bundle name without ".app"; omitted for reveal (handled specially)
+}
+
+const MAC_OPEN_WITH_CATALOG: MacOpenWithApp[] = [
+  { id: "vscode", label: "VS Code", icon: "vscode", kind: "editor", appName: "Visual Studio Code" },
+  { id: "cursor", label: "Cursor", icon: "cursor", kind: "editor", appName: "Cursor" },
+  { id: "zed", label: "Zed", icon: "zed", kind: "editor", appName: "Zed" },
+  { id: "sublime-text", label: "Sublime Text", icon: "sublime-text", kind: "editor", appName: "Sublime Text" },
+  { id: "xcode", label: "Xcode", icon: "xcode", kind: "editor", appName: "Xcode" },
+  { id: "terminal", label: "Terminal", icon: "terminal", kind: "terminal", appName: "Terminal" },
+  { id: "iterm2", label: "iTerm", icon: "iterm2", kind: "terminal", appName: "iTerm" },
+  { id: "ghostty", label: "Ghostty", icon: "ghostty", kind: "terminal", appName: "Ghostty" },
+  { id: "warp", label: "Warp", icon: "warp", kind: "terminal", appName: "Warp" },
+  { id: "finder", label: "Finder", icon: "finder", kind: "reveal" },
+];
+
+const MAC_APP_DIRS = [
+  "/Applications",
+  "/Applications/Utilities",
+  "/System/Applications",
+  "/System/Applications/Utilities",
+  path.join(os.homedir(), "Applications"),
+];
+
+function macAppInstalled(appName: string) {
+  return MAC_APP_DIRS.some((dir) => fsSync.existsSync(path.join(dir, `${appName}.app`)));
+}
+
+type DetectedOpenWithApp = { id: string; label: string; icon: string; kind: MacOpenWithKind };
+
+// The installed-app set doesn't change within a session, and every header mount
+// queries it — so detect once and reuse (each call would otherwise re-run ~45
+// existsSync checks).
+let macOpenWithAppsCache: DetectedOpenWithApp[] | undefined;
+
+function detectMacOpenWithApps(): DetectedOpenWithApp[] {
+  if (!macOpenWithAppsCache) {
+    macOpenWithAppsCache = MAC_OPEN_WITH_CATALOG.filter(
+      (app) => app.kind === "reveal" || (app.appName ? macAppInstalled(app.appName) : false),
+    ).map(({ id, label, icon, kind }) => ({ id, label, icon, kind }));
+  }
+  return macOpenWithAppsCache;
+}
+
+function listOpenWithApps() {
+  if (process.platform === "darwin") return { apps: detectMacOpenWithApps() };
+  // Windows/Linux keep the renderer's existing static list.
+  return { apps: [] as DetectedOpenWithApp[] };
+}
+
+async function openProjectWithMac(projectPath: string, id: string) {
+  const app = MAC_OPEN_WITH_CATALOG.find((entry) => entry.id === id);
+  if (!app) throw new Error("Unsupported open target");
+  if (app.kind === "reveal") {
+    const error = await shell.openPath(projectPath);
+    if (error) throw new Error(error);
+    return;
+  }
+  await launchDetached("open", ["-a", app.appName as string, projectPath], projectPath);
+}
 
 type SkillStoreCatalogItem = {
   id: string;
@@ -952,6 +1023,11 @@ function toWslPath(targetPath: string) {
 
 async function openProjectWith(targetPath: string, target: OpenProjectTarget) {
   const projectPath = assertProjectDirectory(targetPath);
+
+  // On macOS the menu is detection-driven, so any catalog id may arrive here.
+  if (process.platform === "darwin" && MAC_OPEN_WITH_CATALOG.some((app) => app.id === target)) {
+    return openProjectWithMac(projectPath, target);
+  }
 
   if (target === "explorer") {
     const error = await shell.openPath(projectPath);
@@ -1350,6 +1426,7 @@ const handlers: Record<string, (payload?: any) => Promise<any> | any> = {
   close_window: async () => mainWindow?.close(),
   reveal_in_finder: async ({ path: targetPath }) => revealInFinder(targetPath),
   open_project_with: async ({ path: targetPath, target }) => openProjectWith(targetPath, target),
+  list_open_with_apps: async () => listOpenWithApps(),
   show_open_dialog: async (options) => {
     const result = await dialog.showOpenDialog(mainWindow!, {
       title: options?.title,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -35,6 +35,7 @@ const allowedCommands = new Set([
   "close_window",
   "reveal_in_finder",
   "open_project_with",
+  "list_open_with_apps",
   "show_open_dialog",
   "open_external",
   "get_app_info",

--- a/src/components/AgentView.tsx
+++ b/src/components/AgentView.tsx
@@ -9,6 +9,7 @@ import { useNavigate, useParams } from "@solidjs/router"
 import { AssistantPartGroupView, Message } from "@shob-ai/ui/message-part"
 import { DataProvider, FileComponentProvider } from "@shob-ai/ui/context"
 import { AppIcon } from "@shob-ai/ui/app-icon"
+import type { IconName } from "@shob-ai/ui/icons/app"
 import { Icon } from "@shob-ai/ui/icon"
 import { sessionTitle } from "@/utils/session-title"
 import { MacSidebarReveal } from "./mac-chrome"
@@ -63,21 +64,26 @@ interface AgentViewProps {
   reviewDiffs?: () => AgentTurnDiff[]
 }
 
-type OpenWithTarget = "vscode" | "explorer" | "terminal" | "git-bash" | "wsl"
-type OpenWithAppIcon = "vscode" | "file-explorer" | "terminal"
+type OpenWithKind = "editor" | "terminal" | "reveal"
 
-const openWithOptions: Array<{
-  id: OpenWithTarget
+type OpenWithApp = {
+  id: string
   label: string
-  icon?: OpenWithAppIcon
+  icon?: IconName
+  kind: OpenWithKind
   badge?: string
   badgeClass?: string
-}> = [
-  { id: "vscode", label: "VS Code", icon: "vscode" },
-  { id: "explorer", label: "File Explorer", icon: "file-explorer" },
-  { id: "terminal", label: "Terminal", icon: "terminal" },
-  { id: "git-bash", label: "Git Bash", badge: "GB", badgeClass: "bg-surface-success-weak text-text-on-success-base" },
-  { id: "wsl", label: "WSL", badge: "WSL", badgeClass: "bg-surface-info-weak text-text-on-info-base" },
+}
+
+// Windows/Linux fallback. On macOS this is replaced at runtime by the set of
+// editors/terminals actually installed (native `list_open_with_apps`), so the
+// menu shows Finder/Ghostty/Zed/etc. instead of these Windows-centric entries.
+const fallbackOpenWithApps: OpenWithApp[] = [
+  { id: "vscode", label: "VS Code", icon: "vscode", kind: "editor" },
+  { id: "explorer", label: "File Explorer", icon: "file-explorer", kind: "reveal" },
+  { id: "terminal", label: "Terminal", icon: "terminal", kind: "terminal" },
+  { id: "git-bash", label: "Git Bash", kind: "terminal", badge: "GB", badgeClass: "bg-surface-success-weak text-text-on-success-base" },
+  { id: "wsl", label: "WSL", kind: "terminal", badge: "WSL", badgeClass: "bg-surface-info-weak text-text-on-info-base" },
 ]
 
 const unknownNativeCommand = (error: unknown) => String(error instanceof Error ? error.message : error).includes("Unknown IPC command")
@@ -369,7 +375,7 @@ function AgentTurnDiffSummaryCard(props: { message: ChatMessage }) {
   )
 }
 
-function OpenWithOptionIcon(props: { option: (typeof openWithOptions)[number] }) {
+function OpenWithOptionIcon(props: { option: OpenWithApp }) {
   if (props.option.icon) {
     return <AppIcon id={props.option.icon} class="size-5 shrink-0 rounded-[4px]" />
   }
@@ -420,11 +426,15 @@ function AgentHeaderPanelControls(props: { projectPath?: string }) {
   const [isReviewVisible, setIsReviewVisible] = createSignal(false)
   const [isTerminalPanelOpen, setIsTerminalPanelOpen] = createSignal(false)
   const [openWithMenuOpen, setOpenWithMenuOpen] = createSignal(false)
-  const [openingTarget, setOpeningTarget] = createSignal<OpenWithTarget | null>(null)
+  const [openingTarget, setOpeningTarget] = createSignal<string | null>(null)
+  const [openWithApps, setOpenWithApps] = createSignal<OpenWithApp[]>(fallbackOpenWithApps)
+  // The primary (always-visible) button launches the first installed editor,
+  // falling back to whatever the platform offers first (e.g. Finder).
+  const primaryApp = createMemo(() => openWithApps().find((app) => app.kind === "editor") ?? openWithApps()[0])
   const panelButtonClass =
     "size-8 rounded-md border-0 bg-transparent px-0 text-text-weaker shadow-none transition-colors hover:bg-surface-raised-base/45 hover:text-text-base aria-pressed:bg-surface-raised-base/55 aria-pressed:text-text-base focus-visible:ring-2 focus-visible:ring-ring/35 active:not-aria-[haspopup]:translate-y-0"
 
-  const openProjectWith = (target: OpenWithTarget) => {
+  const openProjectWith = (target: string) => {
     const projectPath = props.projectPath?.trim()
     if (!projectPath) {
       showToast({
@@ -462,6 +472,17 @@ function AgentHeaderPanelControls(props: { projectPath?: string }) {
   }
 
   onMount(() => {
+    // Ask the native side which editors/terminals are actually installed. On
+    // macOS this returns a detected, platform-correct list; elsewhere it returns
+    // an empty list and we keep the static fallback above.
+    void nativeApi
+      .invoke("list_open_with_apps")
+      .then((result) => {
+        const apps = (result as { apps?: OpenWithApp[] } | undefined)?.apps
+        if (apps && apps.length > 0) setOpenWithApps(apps)
+      })
+      .catch(() => undefined)
+
     const handleReviewState = (event: Event) => {
       const detail = (event as CustomEvent<{ isReviewVisible: boolean }>).detail
       if (detail) setIsReviewVisible(Boolean(detail.isReviewVisible))
@@ -486,17 +507,22 @@ function AgentHeaderPanelControls(props: { projectPath?: string }) {
         <button
           type="button"
           class="group/open-with flex h-9 w-9 items-center justify-center text-text-weak outline-none transition-colors hover:bg-surface-raised-base-hover hover:text-text-strong focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-60"
-          title="Open in VS Code"
-          aria-label="Open project in VS Code"
-          disabled={Boolean(openingTarget())}
+          title={`Open in ${primaryApp()?.label ?? "editor"}`}
+          aria-label={`Open project in ${primaryApp()?.label ?? "editor"}`}
+          disabled={Boolean(openingTarget()) || !primaryApp()}
           onClick={(event) => {
             event.stopPropagation()
-            openProjectWith("vscode")
+            const app = primaryApp()
+            if (app) openProjectWith(app.id)
           }}
         >
           <Show
-            when={openingTarget() === "vscode"}
-            fallback={<AppIcon id="vscode" class="size-[26px] shrink-0 transition-transform group-hover/open-with:scale-105" />}
+            when={openingTarget() === primaryApp()?.id}
+            fallback={
+              <Show when={primaryApp()?.icon} fallback={<OpenWithOptionIcon option={primaryApp()!} />}>
+                {(icon) => <AppIcon id={icon()} class="size-[26px] shrink-0 transition-transform group-hover/open-with:scale-105" />}
+              </Show>
+            }
           >
             <span class="size-3.5 rounded-full border border-text-weaker border-t-text-strong animate-spin" />
           </Show>
@@ -512,7 +538,7 @@ function AgentHeaderPanelControls(props: { projectPath?: string }) {
             <ChevronDown size={17} strokeWidth={2.25} class="shrink-0" />
           </DropdownMenuTrigger>
           <DropdownMenuContent class="w-[228px] rounded-xl border border-border-weak-base bg-surface-raised-base/95 p-1.5 text-[13px] shadow-2xl backdrop-blur">
-            <For each={openWithOptions}>
+            <For each={openWithApps()}>
               {(option) => (
                 <DropdownMenuItem
                   class="min-h-9 gap-2.5 rounded-lg px-2 py-2 text-[13px] text-text-base focus:bg-surface-raised-base-hover"
@@ -1765,11 +1791,18 @@ function AgentViewInner(props: AgentViewProps) {
           }}
         >
           <div class="agent-terminal-scroll-frame relative min-h-0 flex-1 overflow-hidden">
-            <div class="shob-agent-corner-controls pointer-events-none absolute right-3 top-2 z-40 flex items-center justify-end">
-              <div class="shob-agent-corner-toolbar pointer-events-auto">
-                <AgentHeaderPanelControls projectPath={activeProjectPath()} />
+            {/* On Windows/Linux the title moved into the OS titlebar, so the panel
+                controls float in the now-empty top-right corner. On macOS the in-view
+                header still spans the full width, so a floating overlay would sit on top
+                of the branch switcher and swallow its clicks — there the controls are
+                rendered inline in the header instead (see the mac header below). */}
+            <Show when={!windowChrome.isMac()}>
+              <div class="shob-agent-corner-controls pointer-events-none absolute right-3 top-2 z-40 flex items-center justify-end">
+                <div class="shob-agent-corner-toolbar pointer-events-auto">
+                  <AgentHeaderPanelControls projectPath={activeProjectPath()} />
+                </div>
               </div>
-            </div>
+            </Show>
             <div
               class="pointer-events-none absolute bottom-6 left-1/2 z-[60] -translate-x-1/2 transition-all duration-200 ease-out"
               classList={{
@@ -1829,6 +1862,7 @@ function AgentViewInner(props: AgentViewProps) {
                       {renderTitleCluster()}
                       <div class="ml-auto flex shrink-0 items-center gap-2">
                         {renderBranchSwitcher()}
+                        <AgentHeaderPanelControls projectPath={activeProjectPath()} />
                       </div>
                     </div>
                   </div>
@@ -1869,6 +1903,7 @@ function AgentViewInner(props: AgentViewProps) {
                         <div class="flex w-full items-center justify-end gap-1.5">
                           <MacSidebarReveal class="mr-auto" />
                           {renderBranchSwitcher()}
+                          <AgentHeaderPanelControls projectPath={activeProjectPath()} />
                         </div>
                       </div>
                     </Show>

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -63,7 +63,16 @@ export interface ElectronOpenDialogOptions {
   }>
 }
 
-export type ElectronOpenWithTarget = "vscode" | "explorer" | "terminal" | "git-bash" | "wsl"
+// Windows/Linux use a fixed set; macOS targets are detection-driven (any catalog
+// id from list_open_with_apps), so the type stays open as a string.
+export type ElectronOpenWithTarget = string
+
+export interface ElectronOpenWithApp {
+  id: string
+  label: string
+  icon: string
+  kind: "editor" | "terminal" | "reveal"
+}
 
 export interface ElectronTerminalSpawnOptions {
   id?: string
@@ -339,6 +348,7 @@ export interface NativeCommandMap {
   set_titlebar_theme: { args: { mode: "light" | "dark" }; result: void }
   reveal_in_finder: { args: { path: string }; result: void }
   open_project_with: { args: { path: string; target: ElectronOpenWithTarget }; result: void }
+  list_open_with_apps: { args?: undefined; result: { apps: ElectronOpenWithApp[] } }
   show_open_dialog: { args: ElectronOpenDialogOptions; result: string | string[] | null }
   open_external: { args: { url: string }; result: void }
 }

--- a/src/shob-ported/prompt-input.tsx
+++ b/src/shob-ported/prompt-input.tsx
@@ -2068,7 +2068,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                 data-action="prompt-improve"
                 type="button"
                 disabled={improvingPrompt()}
-                class="size-8 rounded-lg! border border-border/30 hover:bg-accent/50 text-foreground transition-colors duration-150 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
+                class="size-8 flex items-center justify-center rounded-lg! border border-border/30 hover:bg-accent/50 text-foreground transition-colors duration-150 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
                 classList={{
                   "is-busy": improvingPrompt(),
                 }}


### PR DESCRIPTION
## macOS-focused fixes for the agent view

**Header controls** — the Open-with / terminal / review controls floated in an absolute top-right overlay (`z-40`) that sat over the in-view macOS header (`z-30`), swallowing clicks and looking misaligned. On macOS they're now rendered inline in the header; the floating overlay stays for Windows/Linux (where the title moves into the OS titlebar).

**"Open with" menu** — was a hardcoded Windows list (File Explorer, Git Bash, WSL) on every OS. macOS now detects installed apps and shows the right ones — editors (VS Code, Cursor, Zed, Sublime, Xcode), terminals (Terminal, iTerm2, Ghostty, Warp) and Finder — via a new `list_open_with_apps` IPC. Icons already ship in `@shob-ai/ui`, so no new assets. Detection is memoized; Windows/Linux unchanged.

**Improve-prompt icon** — the sparkle button beside Send was missing flex centering, so its SVG sat off-center in its box (most visible on macOS). Now centered like its siblings.

## Screenshot

<img width="302" height="202" alt="Screenshot 2026-06-18 at 10 20 24 AM" src="https://github.com/user-attachments/assets/ed7d8526-d719-4da4-8c86-c02243f94a74" />

## Notes

- macOS-first by design; Windows/Linux keep the existing static list.
- Both `tsc` projects pass; verified live in the dev build (menu detects installed apps; launching opens the project).